### PR TITLE
Adjust README to show installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,37 @@ Format:
     "value": 24 //depends on gesture type
 } 
 ```
+
+# Installation
+
+In order to run the application on a vanilla Raspbian you've to run the following commands:
+
+```
+# Install NodeJS and system libraries
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+sudo apt-get install nodejs
+sudo apt-get install git, libusb-1.0-0-dev, libudev-dev
+
+# Fetch app repository
+mkdir /home/pi/node
+cd /home/pi/node
+git clone https://github.com/wind-rider/nuimo-mqtt-manager.git
+
+# Install TypeScript and NodeJS dependencies
+sudo npm install -g typescript
+sudo npm install -g typings
+typings install --ambient noble node
+typings install dt~node --global --save
+npm install
+
+# Compile TypeScript
+tsc --lib es2015 src/app/app.ts
+
+# Run the compiled application
+sudo node src/app/app.js
+
+#Demonize the application with pm2
+sudo npm install pm2 -g
+sudo pm2 start src/app/app.js
+sudo pm2 save
+```

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Format:
 } 
 ```
 
+(Not implemented yet)
+
+
 ### nuimoEvent
 Gesture event from Nuimo. The apps should listen to this event.
 


### PR DESCRIPTION
Hi,
I haven't used TypeScript yet and others might also have issues running the app, that's why I'd suggest to have some installation instructions in the README. Here's what I kept as installation protocol to run it on a Raspian / Debian Jessie. I assume that this can be simplified when using the TypeScript tools properly.
Cheers