### PR TITLE
Adjust RegEx to also support short UUIDs used by Noble

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -18,11 +18,11 @@ class NuimoMqttManager implements NuimoDelegate {
     appManager = new AppManager();
 
     appTopicRegex = (appId: string): RegExp => {
-        var regex = new RegExp('^nuimo\/(.{8}-?.{4}-?.{4}-?.{4}-?.{12})\/' + appId + '$');
+    var regex = new RegExp('^nuimo\/(.{8}-?.{4}-?.{4}-?.{4}-?.{12}|.{12})\/' + appId + '$');
         return regex;
     };
 
-    genericAppTopicRegex = /^nuimo\/(.{8}-?.{4}-?.{4}-?.{4}-?.{12})\/(.*)$/;
+    genericAppTopicRegex = /^nuimo\/(.{8}-?.{4}-?.{4}-?.{4}-?.{12}|.{12})\/(.*)$/;
     mainTopic = "nuimo";
     logTopic = "nuimo/log";
     appTopic = (appId: string): string => {


### PR DESCRIPTION
Hi,
it seems that depending on the platform or BLE driver the device UUID might be shorter or longer. This PR adjusts the RegEx used to validate the mqtt topics which might also be created with short UUIDs.

In my case the topics created looked like this: "nuimo/f4e82c73c23d/hue".

Cheers